### PR TITLE
Update golang, linters and testing image.

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,7 +6,7 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: lesovsky/pgscv-test-runner:0.0.8
+    container: lesovsky/pgscv-test-runner:0.0.9
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: lesovsky/pgscv-test-runner:0.0.8
+    container: lesovsky/pgscv-test-runner:0.0.9
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # stage 1
-# __release_tag__ golang 1.17 was released 2021-08-16
-FROM golang:1.17 as build
+# __release_tag__ golang 1.18 was released 2022-03-15
+FROM golang:1.18 as build
 LABEL stage=intermediate
 WORKDIR /app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lesovsky/pgscv
 
-go 1.17
+go 1.18
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
-	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1
+	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -49,7 +49,6 @@ github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -68,7 +67,6 @@ github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye47
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=

--- a/testing/docker-test-runner/Dockerfile
+++ b/testing/docker-test-runner/Dockerfile
@@ -1,22 +1,21 @@
 # lesovsky/pgscv-test-runner
 # __release_tag__ postrges 14.2 was released 2022-02-10
-# __release_tag__ golang 1.17 was released 2021-08-16
-# __release_tag__ golangci-lint v1.42.1 was released 2021-09-07
-# __release_tag__ gosec v2.8.1 was released 2021-06-17
+# __release_tag__ golang 1.18 was released 2022-03-15
+# __release_tag__ golangci-lint v1.45.2 was released 2022-03-24
+# __release_tag__ gosec v2.11.0 was released 2022-03-21
 FROM postgres:14.2
 
-LABEL version="0.0.8"
+LABEL version="0.0.9"
 
 # install dependencies
 RUN apt-get update && \
-    apt-get install -y make gcc curl pgbouncer && \
-    curl -s -L https://golang.org/dl/go1.17.linux-amd64.tar.gz -o - | \
-        tar xzf - -C /usr/local && \
+    apt-get install -y make gcc git curl pgbouncer && \
+    curl -s -L https://golang.org/dl/go1.18.linux-amd64.tar.gz -o - | tar xzf - -C /usr/local && \
     cp /usr/local/go/bin/go /usr/local/bin/ && \
-    curl -s -L https://github.com/golangci/golangci-lint/releases/download/v1.42.1/golangci-lint-1.42.1-linux-amd64.tar.gz -o - | \
-        tar xzf - -C /usr/local golangci-lint-1.42.1-linux-amd64/golangci-lint && \
-    cp /usr/local/golangci-lint-1.42.1-linux-amd64/golangci-lint /usr/local/bin/ && \
-    curl -s -L https://github.com/securego/gosec/releases/download/v2.8.1/gosec_2.8.1_linux_amd64.tar.gz -o - | \
+    curl -s -L https://github.com/golangci/golangci-lint/releases/download/v1.45.2/golangci-lint-1.45.2-linux-amd64.tar.gz -o - | \
+        tar xzf - -C /usr/local golangci-lint-1.45.2-linux-amd64/golangci-lint && \
+    cp /usr/local/golangci-lint-1.45.2-linux-amd64/golangci-lint /usr/local/bin/ && \
+    curl -s -L https://github.com/securego/gosec/releases/download/v2.11.0/gosec_2.11.0_linux_amd64.tar.gz -o - | \
         tar xzf - -C /usr/local/bin gosec && \
     mkdir /usr/local/testing/ && \
     rm -rf /var/lib/apt/lists/*
@@ -25,4 +24,4 @@ RUN apt-get update && \
 COPY prepare-test-environment.sh /usr/local/bin/
 COPY fixtures.sql /usr/local/testing/
 
-CMD ["echo", "I'm pgscv test runner 0.0.8"]
+CMD ["echo", "I'm pgscv test runner 0.0.9"]


### PR DESCRIPTION
updates:
- go 1.18
- golangci-lint v1.45.2
- gosec v2.11.0
- pgscv-testing-image 0.0.9