### PR TITLE
Use pg_locks.waitstart for counting waiting time.

### DIFF
--- a/internal/collector/linux_memory_test.go
+++ b/internal/collector/linux_memory_test.go
@@ -82,7 +82,8 @@ func TestMeminfoCollector_Update(t *testing.T) {
 			"node_vmstat_balloon_migrate", "node_vmstat_swap_ra", "node_vmstat_swap_ra_hit", "node_vmstat_nr_foll_pin_acquired",
 			"node_vmstat_pgsteal_anon", "node_vmstat_pgsteal_file", "node_vmstat_pgscan_file", "node_vmstat_pgscan_anon",
 			"node_vmstat_thp_file_fallback_charge", "node_vmstat_nr_foll_pin_released", "node_vmstat_thp_file_fallback",
-			"node_vmstat_thp_fault_fallback_charge",
+			"node_vmstat_thp_fault_fallback_charge", "node_vmstat_nr_swapcached", "node_vmstat_direct_map_level2_splits",
+			"node_vmstat_direct_map_level3_splits",
 		},
 		collector: NewMeminfoCollector,
 	}

--- a/internal/collector/postgres_activity_test.go
+++ b/internal/collector/postgres_activity_test.go
@@ -219,7 +219,11 @@ func Test_selectActivityQuery(t *testing.T) {
 	}{
 		{version: PostgresV95, want: postgresActivityQuery95},
 		{version: PostgresV96, want: postgresActivityQuery96},
-		{version: PostgresV10, want: postgresActivityQueryLatest},
+		{version: PostgresV10, want: postgresActivityQuery13},
+		{version: PostgresV11, want: postgresActivityQuery13},
+		{version: PostgresV12, want: postgresActivityQuery13},
+		{version: PostgresV13, want: postgresActivityQuery13},
+		{version: PostgresV14, want: postgresActivityQueryLatest},
 	}
 
 	for _, tc := range testcases {

--- a/internal/collector/postgres_common.go
+++ b/internal/collector/postgres_common.go
@@ -14,6 +14,7 @@ const (
 	PostgresV95 = 90500
 	PostgresV96 = 90600
 	PostgresV10 = 100000
+	PostgresV11 = 110000
 	PostgresV12 = 120000
 	PostgresV13 = 130000
 	PostgresV14 = 140000


### PR DESCRIPTION
Postgres 14 has pg_locks.waitstart which is more suitable for counting sessions' waiting time instead of pg_stat_activity.state_change.