### PR TITLE
Remove unused props and functions after removing Patroni support

### DIFF
--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -19,8 +19,6 @@ type Config struct {
 	ServiceType string
 	// ConnString defines a connection string used to connecting to the service
 	ConnString string
-	// BaseURL defines a URL string for connecting to HTTP service
-	BaseURL string
 	// NoTrackMode controls collector to gather and send sensitive information, such as queries texts.
 	NoTrackMode bool
 	// postgresServiceConfig defines collector's options specific for Postgres service

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/jackc/pgx/v4"
 	"github.com/lesovsky/pgscv/internal/collector"
-	"github.com/lesovsky/pgscv/internal/http"
 	"github.com/lesovsky/pgscv/internal/log"
 	"github.com/lesovsky/pgscv/internal/model"
 	"github.com/lesovsky/pgscv/internal/store"
@@ -19,7 +18,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 const (
@@ -514,29 +512,6 @@ func attemptConnect(connString string) error {
 
 	db.Close()
 	log.Debug("test connection success")
-
-	return nil
-}
-
-// attemptRequest tries to make a real HTTP request using passed URL string.
-func attemptRequest(baseurl string) error {
-	url := baseurl + "/health"
-	log.Debugln("making test http request: ", url)
-
-	var client = http.NewClient(http.ClientConfig{Timeout: time.Second})
-
-	if strings.HasPrefix(url, "https://") {
-		client.EnableTLSInsecure()
-	}
-
-	resp, err := client.Get(url) // #nosec G107
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad response: %s", resp.Status)
-	}
 
 	return nil
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/lesovsky/pgscv/internal/http"
 	"github.com/lesovsky/pgscv/internal/log"
 	"github.com/lesovsky/pgscv/internal/model"
 	"github.com/prometheus/client_golang/prometheus"
@@ -438,17 +437,6 @@ func Test_newPgbouncerConnectionString(t *testing.T) {
 func Test_attemptConnect(t *testing.T) {
 	assert.NoError(t, attemptConnect("host=127.0.0.1 port=5432 user=pgscv dbname=pgscv_fixtures"))
 	assert.Error(t, attemptConnect("host=127.0.0.1 port=12345 user=invalid dbname=invalid"))
-}
-
-func Test_attemptRequest(t *testing.T) {
-	ts1 := http.TestServer(t, http.StatusOK, "")
-	defer ts1.Close()
-	ts2 := http.TestServer(t, http.StatusBadRequest, "")
-	defer ts2.Close()
-
-	assert.NoError(t, attemptRequest(ts1.URL))
-	assert.Error(t, attemptRequest(ts2.URL))
-	assert.Error(t, attemptRequest("http://127.0.0.1:30080"))
 }
 
 func Test_parsePgbouncerCmdline(t *testing.T) {


### PR DESCRIPTION
- Remove Config.BaseURL property
- Remove attemptRequest() function with tests